### PR TITLE
HOTFIX: true/false word export feedback

### DIFF
--- a/packages/server/services/docx/hhmiDocx.service.js
+++ b/packages/server/services/docx/hhmiDocx.service.js
@@ -976,8 +976,6 @@ class HHMIWaxToDocxConverter extends WaxToDocxConverter {
 
             listContent = listContent.concat([isCorrect, feedback])
           }
-
-          listContent = listContent.concat([isCorrect, ...option.feedback])
         })
 
         content = content.concat(listContent)


### PR DESCRIPTION
Remove duplicated feedback from word export for True/False questions